### PR TITLE
Remove inert_defer and unused_capture_list rules from .swiftlint.yml

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,5 +1,4 @@
 analyzer_rules:
-  - unused_capture_list
   - unused_closure_parameter
   - unused_control_flow_label
   - unused_declaration
@@ -56,7 +55,6 @@ only_rules:
   - identical_operands
   - identifier_name
   - implicit_getter
-  - inert_defer
   - is_disjoint
   - joined_default_parameter
   - large_tuple


### PR DESCRIPTION
This PR contains removing deprecated rules from the swiftlint.yml