### PR TITLE
Remove attributes rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -9,7 +9,6 @@ analyzer_rules:
 
 only_rules:
   - array_init
-  - attributes
   - block_based_kvo
   - closing_brace
   - closure_body_length


### PR DESCRIPTION
This rule is preventing common style patterns such as:

`@Persisted(primaryKey: true) var id: String`