### PR TITLE
create custom modifier only rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -184,7 +184,19 @@ number_separator:
 type_body_length:
   warning: 300
   error: 450
-
+modifier_order:
+  preferred_modifier_order:
+    - acl
+    - setterACL
+    - override
+    - dynamic
+    - mutators
+    - lazy
+    - final
+    - required
+    - convenience
+    - typeMethods
+    - owned
 custom_rules:
   type_inferred_init:
     name: "Type inferred init"


### PR DESCRIPTION
As discussed on [slack](https://infinum.slack.com/archives/C021C5UV347/p1749808026906419), I'm adding a rule that sets a custom modifier order to follow Xcode generated ordering.

The problem with this is that we have to be up to date when new modifiers are added to the language. 

For example:
```
    nonisolated public override func layoutSubviews() {
```
and
```
   public override nonisolated func layoutSubviews() {
```
are both treated as equally valid, while we might have a preferred way to go.


I also don't see a currently available option to control isolation modifier order within SwiftLint. I would expect something like `isolation` but I don't see anything in [their docs](https://realm.github.io/SwiftLint/modifier_order.html).