### PR TITLE
remove deprecation warnings

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -86,7 +86,7 @@ only_rules:
   - number_separator
   - opening_brace
   - operator_usage_whitespace
-  - operator_whitespace
+  - function_name_whitespace
   - optional_enum_case_matching
   - orphaned_doc_comment
   - overridden_super_call
@@ -103,7 +103,7 @@ only_rules:
   - redundant_discardable_let
   - redundant_nil_coalescing
   - redundant_objc_attribute
-  - redundant_optional_initialization
+  - implicit_optional_initialization
   - redundant_set_access_control
   - redundant_string_enum_value
   - redundant_type_annotation


### PR DESCRIPTION
I'm getting these errors during my builds

```
warning: 'operator_whitespace' has been renamed to 'function_name_whitespace' and will be completely removed in a future release.
warning: 'redundant_optional_initialization' has been renamed to 'implicit_optional_initialization' and will be completely removed in a future release.
```